### PR TITLE
Add support for intercepting views created at runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ jdk: oraclejdk8
 android:
   components:
     - tools
-    - android-25
-    - build-tools-25.0.2
     - platform-tools
+    - build-tools-27.0.3
+    - android-27
     - extra-android-m2repository
 
 cache:

--- a/ViewPumpSample/build.gradle
+++ b/ViewPumpSample/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode project.ext.versionCodeInt
         versionName version
     }
@@ -31,12 +31,13 @@ android {
 }
 
 dependencies {
-    compile project(':viewpump')
-    compile 'com.android.support:support-v4:25.3.0'
-    compile 'com.android.support:appcompat-v7:25.3.0'
+    implementation project(':viewpump')
+    implementation 'com.android.support:support-annotations:27.1.1'
+    implementation 'com.android.support:support-v4:27.1.1'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
 
-    compile 'com.jakewharton:butterknife:8.2.1'
+    implementation 'com.jakewharton:butterknife:8.8.1'
 
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5'
-    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
+    releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,15 +2,17 @@
 buildscript {
   repositories {
     jcenter()
+    google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.0'
+    classpath 'com.android.tools.build:gradle:3.1.0'
   }
 }
 
 allprojects {
   repositories {
     jcenter()
+    google()
     mavenLocal()
   }
   // Is Release Build?
@@ -19,9 +21,4 @@ allprojects {
     isReleaseVersion = has("release")
     versionCodeInt = getProperty('VERSION_CODE').toInteger()
   }
-}
-
-task wrapper(type: Wrapper) {
-  gradleVersion = '3.3'
-  distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/viewpump/build.gradle
+++ b/viewpump/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode project.ext.versionCodeInt
         versionName version
         consumerProguardFiles 'consumer-proguard-rules.pro'
@@ -28,11 +28,13 @@ android {
 }
 
 dependencies {
-    provided 'com.android.support:appcompat-v7:25.0.1'
+    compileOnly 'com.android.support:appcompat-v7:27.1.1'
+    compileOnly 'com.android.support:support-annotations:27.1.1'
 
-    testCompile 'org.assertj:assertj-core:1.7.1'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.0.42-beta'
+    testImplementation 'com.android.support:support-annotations:27.1.1'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.assertj:assertj-core:2.6.0'
+    testImplementation 'org.mockito:mockito-core:2.15.0'
 }
 
 apply from: rootProject.file('gradle/deploy.gradle')

--- a/viewpump/src/main/java/io/github/inflationx/viewpump/ReflectiveFallbackViewCreator.java
+++ b/viewpump/src/main/java/io/github/inflationx/viewpump/ReflectiveFallbackViewCreator.java
@@ -1,0 +1,52 @@
+package io.github.inflationx.viewpump;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+import android.view.View;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+class ReflectiveFallbackViewCreator implements FallbackViewCreator {
+
+    private static final Class<?>[] constructorSignature2 = new Class[] {
+            Context.class,
+            AttributeSet.class
+    };
+
+    private static final Class<?>[] constructorSignature1 = new Class[] {
+            Context.class
+    };
+
+    @Nullable
+    @Override
+    public View onCreateView(@Nullable View parent, @NonNull String name, @NonNull Context context, @Nullable AttributeSet attrs) {
+        try {
+            Class<? extends View> clazz = Class.forName(name).asSubclass(View.class);
+            Constructor<? extends View> constructor;
+            Object[] constructorArgs;
+            try {
+                constructor = clazz.getConstructor(constructorSignature2);
+                constructorArgs = new Object[]{context, attrs};
+            } catch (NoSuchMethodException e) {
+                constructor = clazz.getConstructor(constructorSignature1);
+                constructorArgs = new Object[]{context};
+            }
+            constructor.setAccessible(true);
+            return constructor.newInstance(constructorArgs);
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.java
+++ b/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.java
@@ -26,7 +26,7 @@ public final class ViewPump {
     private final boolean mCustomViewCreation;
 
     /** A FallbackViewCreator used to instantiate a view via reflection when using the create() API. */
-    private static ReflectiveFallbackViewCreator mReflectiveFallbackViewCreator;
+    private static FallbackViewCreator mReflectiveFallbackViewCreator;
 
     private ViewPump(Builder builder) {
         interceptors = immutableList(builder.interceptors);
@@ -35,7 +35,7 @@ public final class ViewPump {
         mInterceptorsWithFallback = immutableList(interceptorsWithFallback);
         mReflection = builder.reflection;
         mCustomViewCreation = builder.customViewCreation;
-        mReflectiveFallbackViewCreator = new ReflectiveFallbackViewCreator();
+        mReflectiveFallbackViewCreator = builder.reflectiveFallbackViewCreator;
     }
 
     public static void init(ViewPump viewPump) {
@@ -94,7 +94,7 @@ public final class ViewPump {
         return Collections.unmodifiableList(new ArrayList<>(list));
     }
 
-    private static ReflectiveFallbackViewCreator getReflectiveFallbackViewCreator() {
+    private static FallbackViewCreator getReflectiveFallbackViewCreator() {
         if (mReflectiveFallbackViewCreator == null) {
             mReflectiveFallbackViewCreator = new ReflectiveFallbackViewCreator();
         }
@@ -111,6 +111,9 @@ public final class ViewPump {
 
         /** Use Reflection to intercept CustomView inflation with the correct Context. */
         private boolean customViewCreation = true;
+
+        /** A FallbackViewCreator used to instantiate a view via reflection when using the create() API. */
+        private FallbackViewCreator reflectiveFallbackViewCreator = null;
 
         private Builder() { }
 
@@ -167,6 +170,11 @@ public final class ViewPump {
          */
         public Builder setCustomViewInflationEnabled(boolean enabled) {
             this.customViewCreation = enabled;
+            return this;
+        }
+
+        public Builder setReflectiveFallbackViewCreator(FallbackViewCreator reflectiveFallbackViewCreator) {
+            this.reflectiveFallbackViewCreator = reflectiveFallbackViewCreator;
             return this;
         }
 

--- a/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.java
+++ b/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.java
@@ -1,6 +1,8 @@
 package io.github.inflationx.viewpump;
 
+import android.content.Context;
 import android.support.annotation.MainThread;
+import android.support.annotation.Nullable;
 import android.view.View;
 
 import java.util.ArrayList;
@@ -23,6 +25,9 @@ public final class ViewPump {
     /** Use Reflection to intercept CustomView inflation with the correct Context. */
     private final boolean mCustomViewCreation;
 
+    /** A FallbackViewCreator used to instantiate a view via reflection when using the create() API. */
+    private static ReflectiveFallbackViewCreator mReflectiveFallbackViewCreator;
+
     private ViewPump(Builder builder) {
         interceptors = immutableList(builder.interceptors);
         List<Interceptor> interceptorsWithFallback = builder.interceptors;
@@ -30,6 +35,7 @@ public final class ViewPump {
         mInterceptorsWithFallback = immutableList(interceptorsWithFallback);
         mReflection = builder.reflection;
         mCustomViewCreation = builder.customViewCreation;
+        mReflectiveFallbackViewCreator = new ReflectiveFallbackViewCreator();
     }
 
     public static void init(ViewPump viewPump) {
@@ -42,6 +48,24 @@ public final class ViewPump {
             INSTANCE = builder().build();
         }
         return INSTANCE;
+    }
+
+    /**
+     * Allows for programmatic creation of Views via reflection on class name that are still
+     * pre/post-processed by the inflation interceptors.
+     *
+     * @param context The context.
+     * @param clazz The class of View to be created.
+     * @return The processed view, which might not necessarily be the same type as clazz.
+     */
+    @Nullable
+    public static View create(Context context, Class<? extends View> clazz) {
+        return get().inflate(InflateRequest.builder()
+                .context(context)
+                .name(clazz.getName())
+                .fallbackViewCreator(getReflectiveFallbackViewCreator())
+                .build())
+                .view();
     }
 
     public InflateResult inflate(InflateRequest originalRequest) {
@@ -68,6 +92,13 @@ public final class ViewPump {
     /** Returns an immutable copy of {@code list}. */
     private static <T> List<T> immutableList(List<T> list) {
         return Collections.unmodifiableList(new ArrayList<>(list));
+    }
+
+    private static ReflectiveFallbackViewCreator getReflectiveFallbackViewCreator() {
+        if (mReflectiveFallbackViewCreator == null) {
+            mReflectiveFallbackViewCreator = new ReflectiveFallbackViewCreator();
+        }
+        return mReflectiveFallbackViewCreator;
     }
 
     public static final class Builder {

--- a/viewpump/src/test/java/io/github/inflationx/viewpump/test/ViewPumpTest.java
+++ b/viewpump/src/test/java/io/github/inflationx/viewpump/test/ViewPumpTest.java
@@ -23,6 +23,8 @@ import io.github.inflationx.viewpump.util.TestPostInflationInterceptor;
 import io.github.inflationx.viewpump.util.TestView;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -194,10 +196,10 @@ public class ViewPumpTest {
         View fallbackView = new AnotherTestView(mockContext);
         FallbackViewCreator mockFallbackViewCreator = mock(FallbackViewCreator.class);
         when(mockFallbackViewCreator.onCreateView(
-                    any(View.class),
+                    nullable(View.class),
                     eq(AnotherTestView.NAME),
-                    any(Context.class),
-                    any(AttributeSet.class)))
+                    eq(mockContext),
+                    nullable(AttributeSet.class)))
                 .thenReturn(fallbackView);
 
         InflateResult result = ViewPump.get().inflate(InflateRequest.builder()
@@ -207,7 +209,7 @@ public class ViewPumpTest {
                 .build());
 
         verify(mockFallbackViewCreator)
-                .onCreateView(any(View.class), eq(AnotherTestView.NAME), eq(mockContext), any(AttributeSet.class));
+                .onCreateView(nullable(View.class), eq(AnotherTestView.NAME), eq(mockContext), nullable(AttributeSet.class));
 
         assertThat(result).isNotNull();
         assertThat(result.name()).isEqualTo(AnotherTestView.NAME);

--- a/viewpump/src/test/java/io/github/inflationx/viewpump/test/ViewPumpTest.java
+++ b/viewpump/src/test/java/io/github/inflationx/viewpump/test/ViewPumpTest.java
@@ -4,21 +4,23 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
 import io.github.inflationx.viewpump.FallbackViewCreator;
 import io.github.inflationx.viewpump.InflateRequest;
 import io.github.inflationx.viewpump.InflateResult;
 import io.github.inflationx.viewpump.Interceptor;
 import io.github.inflationx.viewpump.ViewPump;
 import io.github.inflationx.viewpump.util.AnotherTestView;
-import io.github.inflationx.viewpump.util.TestFallbackViewCreator;
-import io.github.inflationx.viewpump.util.NameChangingPreInflationInterceptor;
-import io.github.inflationx.viewpump.util.TestView;
 import io.github.inflationx.viewpump.util.AnotherTestViewNewingPreInflationInterceptor;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import io.github.inflationx.viewpump.util.NameChangingPreInflationInterceptor;
+import io.github.inflationx.viewpump.util.SingleConstructorTestView;
+import io.github.inflationx.viewpump.util.TestFallbackViewCreator;
+import io.github.inflationx.viewpump.util.TestPostInflationInterceptor;
+import io.github.inflationx.viewpump.util.TestView;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -213,5 +215,58 @@ public class ViewPumpTest {
                 .isNotNull()
                 .isInstanceOf(AnotherTestView.class)
                 .isSameAs(fallbackView);
+    }
+
+    @Test
+    public void createView_fromClassName_shouldReturnView() {
+        View view = ViewPump.create(mockContext, TestView.class);
+
+        assertThat(view)
+                .isNotNull()
+                .isInstanceOf(TestView.class);
+
+        assertThat(((TestView) view).isSameContextAs(mockContext)).isTrue();
+    }
+
+    @Test
+    public void createView_fromClassNameWithSingleParamConstructor_shouldReturnView() {
+        View view = ViewPump.create(mockContext, SingleConstructorTestView.class);
+
+        assertThat(view)
+                .isNotNull()
+                .isInstanceOf(SingleConstructorTestView.class);
+
+        assertThat(((SingleConstructorTestView) view).isSameContextAs(mockContext)).isTrue();
+    }
+
+    @Test
+    public void createView_withPreInflationInterceptor_shouldReturnViewWithNewName() {
+        ViewPump.init(ViewPump.builder()
+                .addInterceptor(new NameChangingPreInflationInterceptor())
+                .build());
+
+        View view = ViewPump.create(mockContext, TestView.class);
+
+        assertThat(view)
+                .isNotNull()
+                .isInstanceOf(AnotherTestView.class);
+
+        assertThat(((AnotherTestView) view).isSameContextAs(mockContext)).isTrue();
+    }
+
+    @Test
+    public void createView_withPostInflationInterceptor_shouldReturnPostProcessedView() {
+        ViewPump.init(ViewPump.builder()
+                .addInterceptor(new TestPostInflationInterceptor())
+                .build());
+
+        View view = ViewPump.create(mockContext, TestView.class);
+
+        assertThat(view)
+                .isNotNull()
+                .isInstanceOf(TestView.class);
+
+        assertThat(((TestView) view).isSameContextAs(mockContext)).isTrue();
+        assertThat(((TestView) view).isPostProcessed()).isTrue();
     }
 }

--- a/viewpump/src/test/java/io/github/inflationx/viewpump/util/AnotherTestView.java
+++ b/viewpump/src/test/java/io/github/inflationx/viewpump/util/AnotherTestView.java
@@ -9,11 +9,19 @@ public class AnotherTestView extends View {
 
     public static final String NAME = AnotherTestView.class.getName();
 
+    private Context context;
+
     public AnotherTestView(Context context) {
         super(context);
+        this.context = context;
     }
 
     public AnotherTestView(Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
+        this.context = context;
+    }
+
+    public boolean isSameContextAs(Context context) {
+        return this.context == context;
     }
 }

--- a/viewpump/src/test/java/io/github/inflationx/viewpump/util/SingleConstructorTestView.java
+++ b/viewpump/src/test/java/io/github/inflationx/viewpump/util/SingleConstructorTestView.java
@@ -1,0 +1,20 @@
+package io.github.inflationx.viewpump.util;
+
+import android.content.Context;
+import android.view.View;
+
+public class SingleConstructorTestView extends View {
+
+    public static final String NAME = SingleConstructorTestView.class.getName();
+
+    private Context context;
+
+    public SingleConstructorTestView(Context context) {
+        super(context);
+        this.context = context;
+    }
+
+    public boolean isSameContextAs(Context context) {
+        return this.context == context;
+    }
+}

--- a/viewpump/src/test/java/io/github/inflationx/viewpump/util/TestPostInflationInterceptor.java
+++ b/viewpump/src/test/java/io/github/inflationx/viewpump/util/TestPostInflationInterceptor.java
@@ -1,0 +1,16 @@
+package io.github.inflationx.viewpump.util;
+
+import io.github.inflationx.viewpump.InflateResult;
+import io.github.inflationx.viewpump.Interceptor;
+
+public class TestPostInflationInterceptor implements Interceptor {
+
+    @Override
+    public InflateResult intercept(Chain chain) {
+        InflateResult result = chain.proceed(chain.request());
+        if (result.view() instanceof TestView) {
+            ((TestView) result.view()).setPostProcessed(true);
+        }
+        return result;
+    }
+}

--- a/viewpump/src/test/java/io/github/inflationx/viewpump/util/TestView.java
+++ b/viewpump/src/test/java/io/github/inflationx/viewpump/util/TestView.java
@@ -9,11 +9,31 @@ public class TestView extends View {
 
     public static final String NAME = TestView.class.getName();
 
+    private Context context;
+
+    private boolean isPostProcessed;
+
     public TestView(Context context) {
         super(context);
+        this.context = context;
+        isPostProcessed = false;
     }
 
     public TestView(Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
+        this.context = context;
+        isPostProcessed = false;
+    }
+
+    public boolean isSameContextAs(Context context) {
+        return this.context == context;
+    }
+
+    public boolean isPostProcessed() {
+        return isPostProcessed;
+    }
+
+    public void setPostProcessed(boolean postProcessed) {
+        isPostProcessed = postProcessed;
     }
 }


### PR DESCRIPTION
This allows ViewPump to create views at runtime but still run the requests through the pre/post-inflation interceptors. Addresses #11 