### PR TITLE
Store layout resId in view tag

### DIFF
--- a/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.java
+++ b/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.java
@@ -25,6 +25,9 @@ public final class ViewPump {
     /** Use Reflection to intercept CustomView inflation with the correct Context. */
     private final boolean mCustomViewCreation;
 
+    /** Store the resourceId for the layout used to inflate the View in the View tag. */
+    private final boolean mStoreLayoutResId;
+
     /** A FallbackViewCreator used to instantiate a view via reflection when using the create() API. */
     private static FallbackViewCreator mReflectiveFallbackViewCreator;
 
@@ -35,6 +38,7 @@ public final class ViewPump {
         mInterceptorsWithFallback = immutableList(interceptorsWithFallback);
         mReflection = builder.reflection;
         mCustomViewCreation = builder.customViewCreation;
+        mStoreLayoutResId = builder.storeLayoutResId;
         mReflectiveFallbackViewCreator = builder.reflectiveFallbackViewCreator;
     }
 
@@ -85,6 +89,10 @@ public final class ViewPump {
         return mCustomViewCreation;
     }
 
+    public boolean isStoreLayoutResId() {
+        return mStoreLayoutResId;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -111,6 +119,9 @@ public final class ViewPump {
 
         /** Use Reflection to intercept CustomView inflation with the correct Context. */
         private boolean customViewCreation = true;
+
+        /** Store the resourceId for the layout used to inflate the View in the View tag. */
+        private boolean storeLayoutResId = false;
 
         /** A FallbackViewCreator used to instantiate a view via reflection when using the create() API. */
         private FallbackViewCreator reflectiveFallbackViewCreator = null;
@@ -175,6 +186,17 @@ public final class ViewPump {
 
         public Builder setReflectiveFallbackViewCreator(FallbackViewCreator reflectiveFallbackViewCreator) {
             this.reflectiveFallbackViewCreator = reflectiveFallbackViewCreator;
+            return this;
+        }
+
+        /**
+         * The LayoutInflater can store the layout resourceId used to inflate a view into the inflated view's tag
+         * where it can be later retrieved by an interceptor.
+         *
+         * @param enabled True if the view should store the resId; otherwise, false.
+         */
+        public Builder setStoreLayoutResId(boolean enabled) {
+            this.storeLayoutResId = enabled;
             return this;
         }
 

--- a/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPumpLayoutInflater.java
+++ b/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPumpLayoutInflater.java
@@ -1,6 +1,7 @@
 package io.github.inflationx.viewpump;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -25,8 +26,11 @@ class ViewPumpLayoutInflater extends LayoutInflater implements ViewPumpActivityF
     private boolean mSetPrivateFactory = false;
     private Field mConstructorArgs = null;
 
+    private boolean mStoreLayoutResId = false;
+
     protected ViewPumpLayoutInflater(Context context) {
         super(context);
+        mStoreLayoutResId = ViewPump.get().isStoreLayoutResId();
         nameAndAttrsViewCreator = new NameAndAttrsViewCreator(this);
         parentAndNameAndAttrsViewCreator = new ParentAndNameAndAttrsViewCreator(this);
         setUpLayoutFactories(false);
@@ -34,6 +38,7 @@ class ViewPumpLayoutInflater extends LayoutInflater implements ViewPumpActivityF
 
     protected ViewPumpLayoutInflater(LayoutInflater original, Context newContext, final boolean cloned) {
         super(original, newContext);
+        mStoreLayoutResId = ViewPump.get().isStoreLayoutResId();
         nameAndAttrsViewCreator = new NameAndAttrsViewCreator(this);
         parentAndNameAndAttrsViewCreator = new ParentAndNameAndAttrsViewCreator(this);
         setUpLayoutFactories(cloned);
@@ -48,6 +53,15 @@ class ViewPumpLayoutInflater extends LayoutInflater implements ViewPumpActivityF
     // Wrapping goodies
     // ===
 
+
+    @Override
+    public View inflate(int resource, @Nullable ViewGroup root, boolean attachToRoot) {
+        View view = super.inflate(resource, root, attachToRoot);
+        if (view != null && mStoreLayoutResId) {
+            view.setTag(R.id.viewpump_layout_res, resource);
+        }
+        return view;
+    }
 
     @Override
     public View inflate(XmlPullParser parser, ViewGroup root, boolean attachToRoot) {

--- a/viewpump/src/main/res/values/ids.xml
+++ b/viewpump/src/main/res/values/ids.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="viewpump_tag_id" type="id"/>
+    <item name="viewpump_layout_res" type="id"/>
 </resources>


### PR DESCRIPTION
Tagging a view with the layout resourceId used to inflate it could be useful for a variety of applications from displaying the information in Stetho to using the information in a ViewPump interceptor. This functionality is opt-in and disabled by default.