### PR TITLE
Disable generation of buildconfig

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/viewpump/build.gradle
+++ b/viewpump/build.gradle
@@ -29,6 +29,10 @@ android {
         textOutput 'stdout'
         textReport System.getenv('CI') == 'true'
     }
+    libraryVariants.all {
+        // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
+        it.generateBuildConfig.enabled = false
+    }
 }
 
 dokka {

--- a/viewpump/build.gradle
+++ b/viewpump/build.gradle
@@ -36,19 +36,8 @@ android {
 }
 
 dokka {
-    // These don't quite work yet with the maven publish plugin
-    externalDocumentationLink {
-        url = new URL("https://developer.android.com/reference/")
-        packageListUrl =
-            new URL("https://developer.android.com/reference/package-list")
-    }
-    externalDocumentationLink {
-        url = new URL("https://docs.oracle.com/javase/7/docs/api/")
-    }
-
     includeNonPublic = false
     skipDeprecated = true
-    outputFormat = 'html' // Overridden by the publish plugin for now
     includes = ['Module.md']
 }
 


### PR DESCRIPTION
It's unnecessary for the project and makes this an annoyingly mixed source set