### PR TITLE
Remove unnecessary consumer proguard files

### DIFF
--- a/viewpump/build.gradle
+++ b/viewpump/build.gradle
@@ -13,13 +13,12 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 28
-        consumerProguardFiles 'consumer-proguard-rules.pro'
     }
 
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'consumer-proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
 

--- a/viewpump/consumer-proguard-rules.pro
+++ b/viewpump/consumer-proguard-rules.pro
@@ -1,2 +1,0 @@
--keep class io.github.inflationx.viewpump.* { *; }
--keep class io.github.inflationx.viewpump.*$* { *; }


### PR DESCRIPTION
We are only reflecting on `View` and `LayoutInflater`, so we don't need to keep the entire library to make it safe to use with Proguard. Launched the sample app and unit tests passed. Resolves #35 

<img src="https://user-images.githubusercontent.com/3178606/55213480-98bb0c80-51b0-11e9-9d2c-4aa58cdfbf4c.png" width="320">
