### PR TITLE
Fix SAM invocation of Interceptor instances

### DIFF
--- a/viewpump/src/main/java/io/github/inflationx/viewpump/Interceptor.kt
+++ b/viewpump/src/main/java/io/github/inflationx/viewpump/Interceptor.kt
@@ -9,6 +9,16 @@ package io.github.inflationx.viewpump
 interface Interceptor {
   fun intercept(chain: Chain): InflateResult
 
+  companion object {
+    // This lambda conversion is for Kotlin callers expecting a Java SAM (single-abstract-method).
+    @JvmName("-deprecated_Interceptor")
+    inline operator fun invoke(
+        crossinline block: (chain: Chain) -> InflateResult
+    ): Interceptor = object: Interceptor {
+      override fun intercept(chain: Chain) = block(chain)
+    }
+  }
+
   interface Chain {
     fun request(): InflateRequest
 


### PR DESCRIPTION
This broke for kotlin users with 2.x, and this fix is borrowing from OkHttp's solution.

This allows us to do this again in Kotlin:

```kotlin
builder.addInterceptor {
  // Stuff
}
```