### PR TITLE
Add Builder.addInterceptor() convenience extension function

### DIFF
--- a/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.kt
+++ b/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.kt
@@ -3,6 +3,8 @@ package io.github.inflationx.viewpump
 import android.content.Context
 import android.view.View
 import androidx.annotation.MainThread
+import io.github.inflationx.viewpump.Interceptor.Chain
+import io.github.inflationx.viewpump.ViewPump.Builder
 import io.github.inflationx.viewpump.internal.`-FallbackViewCreationInterceptor`
 import io.github.inflationx.viewpump.internal.`-InterceptorChain`
 import io.github.inflationx.viewpump.internal.`-ReflectiveFallbackViewCreator`
@@ -183,4 +185,11 @@ class ViewPump private constructor(
       return Builder()
     }
   }
+}
+
+/**
+ * Adds an [Interceptor] to this current [Builder] for idiomatic Kotlin higher order function usage.
+ */
+inline fun Builder.addInterceptor(crossinline block: (chain: Chain) -> InflateResult) = apply {
+  addInterceptor(Interceptor.invoke(block))
 }


### PR DESCRIPTION
This works in tandem with the `invoke()` alternative

This actually actually allows us to do what #44 was starting

```kotlin
builder.addInterceptor {
 // Stuff
}
```