### PR TITLE
Don't reflectively set context during inflation on Q

### DIFF
--- a/viewpump/src/main/java/io/github/inflationx/viewpump/internal/-ViewPumpLayoutInflater.kt
+++ b/viewpump/src/main/java/io/github/inflationx/viewpump/internal/-ViewPumpLayoutInflater.kt
@@ -2,6 +2,7 @@
 package io.github.inflationx.viewpump.internal
 
 import android.content.Context
+import android.os.Build
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
@@ -20,6 +21,8 @@ internal class `-ViewPumpLayoutInflater`(
     newContext: Context,
     cloned: Boolean
 ) : LayoutInflater(original, newContext), `-ViewPumpActivityFactory` {
+
+  private val IS_AT_LEAST_Q = Build.VERSION.SDK_INT > Build.VERSION_CODES.P || BuildCompat.isAtLeastQ()
 
   private val nameAndAttrsViewCreator: FallbackViewCreator = NameAndAttrsViewCreator(this)
   private val parentAndNameAndAttrsViewCreator: FallbackViewCreator = ParentAndNameAndAttrsViewCreator(this)
@@ -202,7 +205,7 @@ internal class `-ViewPumpLayoutInflater`(
     // If CustomViewCreation is off skip this.
     if (!ViewPump.get().isCustomViewCreation) return mutableView
     if (mutableView == null && name.indexOf('.') > -1) {
-      if (BuildCompat.isAtLeastQ()) {
+      if (IS_AT_LEAST_Q) {
         mutableView = cloneInContext(viewContext).createView(name, null, attrs)
       } else {
         @Suppress("UNCHECKED_CAST")

--- a/viewpump/src/main/java/io/github/inflationx/viewpump/internal/-ViewPumpLayoutInflater.kt
+++ b/viewpump/src/main/java/io/github/inflationx/viewpump/internal/-ViewPumpLayoutInflater.kt
@@ -6,6 +6,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.BuildCompat
 import io.github.inflationx.viewpump.FallbackViewCreator
 import io.github.inflationx.viewpump.InflateRequest
 import io.github.inflationx.viewpump.R.id
@@ -201,20 +202,24 @@ internal class `-ViewPumpLayoutInflater`(
     // If CustomViewCreation is off skip this.
     if (!ViewPump.get().isCustomViewCreation) return mutableView
     if (mutableView == null && name.indexOf('.') > -1) {
-      @Suppress("UNCHECKED_CAST")
-      val constructorArgsArr = CONSTRUCTOR_ARGS_FIELD.get(this) as Array<Any>
-      val lastContext = constructorArgsArr[0]
-      // The LayoutInflater actually finds out the correct context to use. We just need to set
-      // it on the mConstructor for the internal method.
-      // Set the constructor ars up for the createView, not sure why we can't pass these in.
-      constructorArgsArr[0] = viewContext
-      CONSTRUCTOR_ARGS_FIELD.setValueQuietly(this, constructorArgsArr)
-      try {
-        mutableView = createView(name, null, attrs)
-      } catch (ignored: ClassNotFoundException) {
-      } finally {
-        constructorArgsArr[0] = lastContext
+      if (BuildCompat.isAtLeastQ()) {
+        mutableView = cloneInContext(viewContext).createView(name, null, attrs)
+      } else {
+        @Suppress("UNCHECKED_CAST")
+        val constructorArgsArr = CONSTRUCTOR_ARGS_FIELD.get(this) as Array<Any>
+        val lastContext = constructorArgsArr[0]
+        // The LayoutInflater actually finds out the correct context to use. We just need to set
+        // it on the mConstructor for the internal method.
+        // Set the constructor ars up for the createView, not sure why we can't pass these in.
+        constructorArgsArr[0] = viewContext
         CONSTRUCTOR_ARGS_FIELD.setValueQuietly(this, constructorArgsArr)
+        try {
+          mutableView = createView(name, null, attrs)
+        } catch (ignored: ClassNotFoundException) {
+        } finally {
+          constructorArgsArr[0] = lastContext
+          CONSTRUCTOR_ARGS_FIELD.setValueQuietly(this, constructorArgsArr)
+        }
       }
     }
     return mutableView


### PR DESCRIPTION
In order to fix the NonSdkApiUsedViolation reported in #21 and #48, we no longer set the context or attrs on the recently created custom view. This was already fixed in P, so the work is no longer necessary. Thanks to @chrisjenx for discovering this.