### PR TITLE
Added a method to overwrite the Context used by ViewPumps layout inflater

### DIFF
--- a/ViewPumpSample/build.gradle
+++ b/ViewPumpSample/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 14

--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,10 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.3.2'
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.21'
+    classpath 'com.android.tools.build:gradle:4.0.1'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.0'
     classpath 'org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18'
-    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT'
+    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.9.0'
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Aug 28 19:27:46 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/viewpump/build.gradle
+++ b/viewpump/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
-apply plugin: 'org.jetbrains.dokka-android'
+apply plugin: 'org.jetbrains.dokka'
 
 dokka {
     reportUndocumented = false
@@ -19,12 +19,11 @@ dokka {
 }
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 30
     }
     lintOptions {
         // we don't always want to use the latest version of the support library
@@ -32,11 +31,8 @@ android {
         textOutput 'stdout'
         textReport System.getenv('CI') == 'true'
     }
-    libraryVariants.all {
-        // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
-        it.generateBuildConfigProvider.configure {
-            it.enabled = false
-        }
+    buildFeatures {
+        buildConfig = false
     }
     variantFilter { variant ->
         if (variant.buildType.name == 'debug') {
@@ -46,15 +42,15 @@ android {
 }
 
 dependencies {
-    compileOnly 'androidx.appcompat:appcompat:1.0.2'
-    api 'org.jetbrains.kotlin:kotlin-stdlib:1.3.21'
+    compileOnly 'androidx.appcompat:appcompat:1.2.0'
+    api 'org.jetbrains.kotlin:kotlin-stdlib:1.4.0'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     testImplementation 'org.assertj:assertj-core:3.11.0'
-    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation 'org.mockito:mockito-core:3.4.6'
 
-    testImplementation 'androidx.annotation:annotation:1.0.2'
-    testImplementation 'androidx.test:runner:1.1.1'
+    testImplementation 'androidx.annotation:annotation:1.1.0'
+    testImplementation 'androidx.test:runner:1.3.0'
 }
 
 apply plugin: 'com.vanniktech.maven.publish'

--- a/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.kt
+++ b/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.kt
@@ -1,6 +1,7 @@
 package io.github.inflationx.viewpump
 
 import android.content.Context
+import android.view.LayoutInflater
 import android.view.View
 import androidx.annotation.MainThread
 import io.github.inflationx.viewpump.Interceptor.Chain
@@ -8,6 +9,7 @@ import io.github.inflationx.viewpump.ViewPump.Builder
 import io.github.inflationx.viewpump.internal.`-FallbackViewCreationInterceptor`
 import io.github.inflationx.viewpump.internal.`-InterceptorChain`
 import io.github.inflationx.viewpump.internal.`-ReflectiveFallbackViewCreator`
+import io.github.inflationx.viewpump.internal.`-ViewPumpLayoutInflater`
 
 class ViewPump private constructor(
     /** List of interceptors.  */
@@ -178,6 +180,19 @@ class ViewPump private constructor(
               fallbackViewCreator = reflectiveFallbackViewCreator
           ))
           .view
+    }
+
+    /**
+     * Overwrites the context which ViewPumps [LayoutInflater] provides to views when inflating them
+     * from the provided context, meaning they will use the provided context to resolve their
+     * resources.
+     *
+     * @param context The context
+     */
+    @JvmStatic
+    fun setOverwriteContext(context: Context) {
+      val inflater = (LayoutInflater.from(context) as? `-ViewPumpLayoutInflater`)
+      inflater?.overwriteContext = context
     }
 
     @JvmStatic


### PR DESCRIPTION
Thanks for the library, I am using it in two libraries of mine.
I need a small new feature however:
In my libraries I am wrapping the Resources, to replace string xml resources. This works, however there are some issues with the context used by ViewPumps LayoutInflater and the one I use in my Fragments getting out of sync leading to crashes due to missing resources. A simple fix is to just overwrite the context used by ViewPump like in this PR. I tried this out on a private project and it works as expected. If you can include this in your lib would be cool :)

I also needed to update the Build files a bit, to make them work with the new Android Studio, I hope this is all right.