### PR TITLE
Add ViewPump.reset() function

### DIFF
--- a/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.kt
+++ b/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.kt
@@ -152,7 +152,7 @@ class ViewPump private constructor(
     }
 
     @JvmStatic
-    fun init(viewPump: ViewPump?) {
+    fun init(viewPump: ViewPump) {
       INSTANCE = viewPump
     }
 

--- a/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.kt
+++ b/viewpump/src/main/java/io/github/inflationx/viewpump/ViewPump.kt
@@ -156,6 +156,12 @@ class ViewPump private constructor(
       INSTANCE = viewPump
     }
 
+    /** Resets the current singleton instance. This should usually only be used for testing. */
+    @JvmStatic
+    fun reset() {
+      INSTANCE = null
+    }
+
     @JvmStatic
     @MainThread
     fun get(): ViewPump {
@@ -177,7 +183,7 @@ class ViewPump private constructor(
      * @return The processed view, which might not necessarily be the same type as clazz.
      */
     @JvmStatic
-    fun create(context: Context, clazz: Class<out View>, attrs :AttributeSet): View? {
+    fun create(context: Context, clazz: Class<out View>, attrs: AttributeSet): View? {
       return get()
           .inflate(InflateRequest(
               context = context,

--- a/viewpump/src/test/java/io/github/inflationx/viewpump/test/ViewPumpTest.java
+++ b/viewpump/src/test/java/io/github/inflationx/viewpump/test/ViewPumpTest.java
@@ -39,7 +39,6 @@ public class ViewPumpTest {
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        ViewPump.init(null);
     }
 
     @After

--- a/viewpump/src/test/java/io/github/inflationx/viewpump/test/ViewPumpTest.java
+++ b/viewpump/src/test/java/io/github/inflationx/viewpump/test/ViewPumpTest.java
@@ -15,6 +15,8 @@ import io.github.inflationx.viewpump.util.SingleConstructorTestView;
 import io.github.inflationx.viewpump.util.TestFallbackViewCreator;
 import io.github.inflationx.viewpump.util.TestPostInflationInterceptor;
 import io.github.inflationx.viewpump.util.TestView;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -38,6 +40,11 @@ public class ViewPumpTest {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         ViewPump.init(null);
+    }
+
+    @After
+    public void tearDown() {
+        ViewPump.reset();
     }
 
     @Test
@@ -272,5 +279,23 @@ public class ViewPumpTest {
 
         assertThat(((TestView) view).isSameContextAs(mockContext)).isTrue();
         assertThat(((TestView) view).isPostProcessed()).isTrue();
+    }
+
+    @Test
+    public void reset() {
+        ViewPump first = ViewPump.builder()
+                .addInterceptor(new TestPostInflationInterceptor())
+                .build();
+        ViewPump.init(first);
+
+        assertThat(ViewPump.get())
+                .isSameAs(first);
+
+        // Now reset
+        ViewPump.reset();
+
+        // Now it's cleared the previously installed one
+        assertThat(ViewPump.get())
+                .isNotSameAs(first);
     }
 }


### PR DESCRIPTION
This allows for tearing down the viewpump singleton instance in tests.